### PR TITLE
03) Exceeds limit — “skips ALL new changed-files labels when count exceeds limit”

### DIFF
--- a/app/trigger-run-a.txt
+++ b/app/trigger-run-a.txt
@@ -1,1 +1,0 @@
-trigger run A - apply 100 app labels (main branch setLabels test)

--- a/app/trigger-run-a.txt
+++ b/app/trigger-run-a.txt
@@ -1,0 +1,1 @@
+trigger run A - apply 100 app labels (main branch setLabels test)

--- a/components/a/file.txt
+++ b/components/a/file.txt
@@ -1,1 +1,2 @@
 placeholder
+Exceeds limit — “skips ALL new changed-files labels when count exceeds limit”

--- a/components/b/file.txt
+++ b/components/b/file.txt
@@ -1,1 +1,2 @@
 placeholder
+Exceeds limit — “skips ALL new changed-files labels when count exceeds limit”

--- a/components/c/file.txt
+++ b/components/c/file.txt
@@ -1,1 +1,2 @@
 placeholder
+Exceeds limit — “skips ALL new changed-files labels when count exceeds limit”

--- a/src/trigger-run-b.txt
+++ b/src/trigger-run-b.txt
@@ -1,0 +1,1 @@
+trigger run B - apply 100 src labels via setLabels (main branch)


### PR DESCRIPTION
This pull request introduces a small but important change to the project: it clarifies behavior when the number of changed files exceeds a set limit. Specifically, it adds a note explaining that in such cases, all new changed-files labels will be skipped.

* Documentation update: Added a description to `components/a/file.txt`, `components/b/file.txt`, and `components/c/file.txt` stating that when the count exceeds the limit, all new changed-files labels are skipped.