### PR TITLE
5) Limit = 0 — “skips all changed-files labels always”

### DIFF
--- a/components/a/file.txt
+++ b/components/a/file.txt
@@ -1,1 +1,2 @@
 placeholder
+test/limit-zero

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,1 +1,2 @@
 placeholder
+test/limit-zero


### PR DESCRIPTION
This pull request introduces a minor change, adding the string `test/limit-zero` to both the `components/a/file.txt` and `docs/readme.md` files.