### PR TITLE
6) Pre-existing labels are not counted toward the limit

### DIFF
--- a/components/a/file.txt
+++ b/components/a/file.txt
@@ -1,1 +1,2 @@
 placeholder
+feature/preexisting

--- a/components/b/file.txt
+++ b/components/b/file.txt
@@ -1,1 +1,2 @@
 placeholder
+feature/preexisting

--- a/components/c/file.txt
+++ b/components/c/file.txt
@@ -1,1 +1,2 @@
 placeholder
+6) Pre-existing labels are not counted toward the limit

--- a/components/d/file.txt
+++ b/components/d/file.txt
@@ -1,1 +1,2 @@
 placeholder
+6) Pre-existing labels are not counted toward the limit


### PR DESCRIPTION
This pull request adds the `feature/preexisting` marker to two component files, likely indicating that these components are now tracked as preexisting features.

Feature tracking updates:

* Added `feature/preexisting` to `components/a/file.txt` to mark the component as preexisting.
* Added `feature/preexisting` to `components/b/file.txt` to mark the component as preexisting.